### PR TITLE
blackbox gyro orientation adjustment and camera angle compensation

### DIFF
--- a/blackbox_extract.py
+++ b/blackbox_extract.py
@@ -14,16 +14,16 @@ class BlackboxExtractor:
         for lg in range(1,self.n_of_logs+1):
             self.parser.set_log_index(lg)
             t  = self.parser.field_names.index('time')
-            gx = self.parser.field_names.index('gyroADC[0]')
-            gy = self.parser.field_names.index('gyroADC[1]')
-            gz = self.parser.field_names.index('gyroADC[2]')
+            gx = self.parser.field_names.index('gyroADC[1]')
+            gy = self.parser.field_names.index('gyroADC[2]')
+            gz = self.parser.field_names.index('gyroADC[0]')
 
             data_frames = []
             for frame in self.parser.frames():
                 f = [frame.data[t]/1000000,
-                     math.radians(frame.data[gx]),
+                     -math.radians(frame.data[gx]),
                      math.radians(frame.data[gy]),
-                     math.radians(frame.data[gz])]
+                     -math.radians(frame.data[gz])]
                 data_frames.append(f)
 
             self.final_gyro_data.extend(data_frames)    

--- a/blackbox_extract.py
+++ b/blackbox_extract.py
@@ -1,4 +1,5 @@
 from orangebox import Parser
+from scipy.spatial.transform import Rotation
 import math
 import numpy as np
 
@@ -9,23 +10,34 @@ class BlackboxExtractor:
         self.n_of_logs = self.parser.reader.log_count
         self.gyro_scale = self.parser.headers["gyro_scale"] #should be already scaled in the fc
         self.final_gyro_data = []
+        self.camera_angle = None
 
-    def get_gyro_data(self):
+    def get_gyro_data(self,cam_angle_degrees):
+        
+        self.camera_angle = cam_angle_degrees
+        r  = Rotation.from_euler('x', self.camera_angle, degrees=True)
+        
         for lg in range(1,self.n_of_logs+1):
             self.parser.set_log_index(lg)
             t  = self.parser.field_names.index('time')
             gx = self.parser.field_names.index('gyroADC[1]')
             gy = self.parser.field_names.index('gyroADC[2]')
             gz = self.parser.field_names.index('gyroADC[0]')
-
             data_frames = []
+            
             for frame in self.parser.frames():
+                to_rotate = [-math.radians(frame.data[gx]),
+                             math.radians(frame.data[gy]),
+                             -math.radians(frame.data[gz])]
+                
+                rotated = r.apply(to_rotate)
+                
                 f = [frame.data[t]/1000000,
-                     -math.radians(frame.data[gx]),
-                     math.radians(frame.data[gy]),
-                     -math.radians(frame.data[gz])]
+                     rotated[0],
+                     rotated[1],
+                     rotated[2]]
                 data_frames.append(f)
-
+                
             self.final_gyro_data.extend(data_frames)    
         return np.array(self.final_gyro_data)
 


### PR DESCRIPTION
matched gpmf gyro data orientation following the scheme:
gpmf gyro => bf gyro
x => -y
y => z
z => -x
added camera angle compensation: 
cam_angle_degrees parameter to get_gyro_data  should be given as negative orientation ex. -30°

added scipy dependency (for rotating the data)