### PR TITLE
Restructure encoder choice add support for prores

### DIFF
--- a/gyroflow.py
+++ b/gyroflow.py
@@ -1724,6 +1724,7 @@ class StabUtilityBarebone(QtWidgets.QMainWindow):
                 break
 
         self.video_encoder_select.currentIndexChanged.connect(self.update_profile_select)
+        self.video_encoder_select.currentIndexChanged.connect(self.update_bitrate_visibility)
         self.update_profile_select()
         
         self.export_controls_layout.addWidget(self.video_encoder_text)
@@ -1745,13 +1746,16 @@ class StabUtilityBarebone(QtWidgets.QMainWindow):
         self.export_controls_layout.addWidget(self.export_debug_text)
 
         # TODO: Should consider hiding this widget if prores is selected
-        self.export_controls_layout.addWidget(QtWidgets.QLabel("Export bitrate [Mbit/s]"))
+        self.export_bitrate_text = QtWidgets.QLabel("Export bitrate [Mbit/s]")
+        self.export_controls_layout.addWidget(self.export_bitrate_text)
         self.export_bitrate = QtWidgets.QDoubleSpinBox(self)
         self.export_bitrate.setDecimals(0)
         self.export_bitrate.setMinimum(1)
         self.export_bitrate.setMaximum(200)
         self.export_bitrate.setValue(20)
+        self.export_bitrate.setVisible(True)
         self.export_controls_layout.addWidget(self.export_bitrate)
+        self.update_bitrate_visibility()
 
         #yuv420p
         self.export_controls_layout.addWidget(QtWidgets.QLabel("FFmpeg color space selection (Try 'yuv420p' if output doesn't play):"))
@@ -2182,6 +2186,14 @@ class StabUtilityBarebone(QtWidgets.QMainWindow):
         self.encoder_profile_select.setRootModelIndex(encoder_index)
         self.encoder_profile_select.setCurrentIndex(0)
 
+    def update_bitrate_visibility(self):
+        encoders_without_bitrate_control = ["prores_ks"]
+        if self.video_encoder_select.currentText() in encoders_without_bitrate_control:
+            enable_bitrate = False
+        else:
+            enable_bitrate = True
+        self.export_bitrate_text.setVisible(enable_bitrate)
+        self.export_bitrate.setVisible(enable_bitrate)
 
 def main():
     QtCore.QLocale.setDefault(QtCore.QLocale(QtCore.QLocale.English, QtCore.QLocale.UnitedStates))

--- a/gyroflow.py
+++ b/gyroflow.py
@@ -2202,7 +2202,11 @@ class StabUtilityBarebone(QtWidgets.QMainWindow):
         index = self.video_encoder_select.currentIndex()
         encoder_index = self.encoder_model.index(index, 0, self.video_encoder_select.rootModelIndex())
         self.encoder_profile_select.setRootModelIndex(encoder_index)
-        self.encoder_profile_select.setCurrentIndex(0)
+        h264_encoders = ["libx264", "h264_videotoolbox", "h264_vaapi", "h264_nvenc"]
+        if self.video_encoder_select.currentText() in h264_encoders and self.encoder_profile_select.count() > 2:
+            self.encoder_profile_select.setCurrentIndex(2)  # Make "high" default profile for standard h264 encoders
+        else:
+            self.encoder_profile_select.setCurrentIndex(0)
 
     def update_bitrate_visibility(self):
         encoders_without_bitrate_control = ["prores_ks"]

--- a/gyroflow.py
+++ b/gyroflow.py
@@ -1777,7 +1777,7 @@ class StabUtilityBarebone(QtWidgets.QMainWindow):
 
         # warning for HW encoding
         render_description = QtWidgets.QLabel(
-        "<b>Note:</b> HW Encoding requires FFMpeg with hardware acceleration support!")
+        "<b>Note:</b> videotoolbox, vaapi and nvenc are HW accelerated encoders and require FFmpeg with hardware acceleration support!")
         render_description.setWordWrap(True)
         self.export_controls_layout.addWidget(render_description)
 

--- a/gyroflow.py
+++ b/gyroflow.py
@@ -1692,7 +1692,7 @@ class StabUtilityBarebone(QtWidgets.QMainWindow):
         supported_encoders = {
             "libx264": ["baseline", "main", "high", "high10", "high422", "hight444"], 
             "h264_nvenc": ["baseline", "main", "high", "high444p"],
-            "h264_vaapi": ["main"],
+            "h264_vaapi": ["baseline", "main", "high"],
             "h264_videotoolbox": ["baseline", "main", "high", "extended"], 
             "prores_ks": ["auto", "proxy", "lt", "standard", "hq", "4444", "4444xq"]
         }

--- a/stabilizer.py
+++ b/stabilizer.py
@@ -573,15 +573,16 @@ class Stabilizer:
 
 
     def renderfile(self, starttime, stoptime, outpath = "Stabilized.mp4", out_size = (1920,1080), split_screen = True,
-                   bitrate_mbits = 20, display_preview = False, scale=1, vcodec = "libx264", pix_fmt = "", debug_text = False,
-                   custom_ffmpeg = ""):
+                   bitrate_mbits = 20, display_preview = False, scale=1, vcodec = "libx264", vprofile="main", pix_fmt = "",
+                   debug_text = False, custom_ffmpeg = ""):
         
         export_out_size = (int(out_size[0]*2*scale) if split_screen else int(out_size[0]*scale), int(out_size[1]*scale))
 
         if vcodec == "libx264":
             output_params = {
                 "-input_framerate": self.fps, 
-                "-c:v": "libx264",
+                "-vcodec": "libx264",
+                "-profile:v": vprofile,
                 "-crf": "1",  # Can't use 0 as it triggers "lossless" which does not allow  -maxrate
                 "-maxrate": "%sM" % bitrate_mbits,
                 "-bufsize": "%sM" % int(bitrate_mbits * 1.2),
@@ -591,40 +592,31 @@ class Stabilizer:
             output_params = {
                 "-input_framerate": self.fps, 
                 "-vcodec": "h264_nvenc",
-                "-profile:v": "high",
+                "-profile:v": vprofile,
                 "-rc:v": "cbr", 
                 "-b:v": "%sM" % bitrate_mbits,
                 "-bufsize:v": "%sM" % int(bitrate_mbits * 2),
-                "-pix_fmt": "yuv420p",
             }
         elif vcodec == "h264_vaapi":
             output_params = {
                 "-input_framerate": self.fps, 
                 "-vcodec": "h264_vaapi",
                 "-vaapi_device": "/dev/dri/renderD128",
-                "-profile": "high", 
+                "-profile:v": vprofile, 
                 "-b:v": "%sM" % bitrate_mbits,
-                "-pix_fmt": "yuv420p",
             }
         elif vcodec == "h264_videotoolbox":
             output_params = {
                 "-input_framerate": self.fps, 
                 "-vcodec": "h264_videotoolbox",
-                "-profile": "high", 
+                "-profile:v": vprofile, 
                 "-b:v": "%sM" % bitrate_mbits,
-                "-pix_fmt": "yuv420p",
                 }
-        elif vcodec == "prores_ks_hq":
+        elif vcodec == "prores_ks":
             output_params = {
                 "-input_framerate": self.fps, 
                 "-vcodec": "prores_ks",
-                "-profile:v": "hq",
-            }
-        elif vcodec == "prores_ks_4444":
-            output_params = {
-                "-input_framerate": self.fps, 
-                "-vcodec": "prores_ks",
-                "-profile:v": "4444",
+                "-profile:v": vprofile,
             }
         else:
             output_params = {}


### PR DESCRIPTION
Tested successfully with ProRes 422 video and 4444 video.
Added a more tidy(?) implementation of choosing encoders, should probably hide/grey out encoders that ffmpeg are not able to find

Bitrate option does not affect ProRes. Will check with more of the CineLifter guys if any other settings should be modified.

The "untested" custom ffmpeg field did not work very well as parameters varies by the encoder chosen, so I suggest we make it a "custom ffmpeg pipeline" field where advanced users can override the settings if needed. Should probably add link to documentation for this and potentially hide it behind "show advanced settings" or similar.

Let me know if you have any suggestions @ElvinC 