### PR TITLE
Added Hawkeye Firefly X Lite camera presets

### DIFF
--- a/camera_presets/Hawkeye/Hawkeye_Firefly_X_Lite_2_5K_50fps_16by9_Wide.json
+++ b/camera_presets/Hawkeye/Hawkeye_Firefly_X_Lite_2_5K_50fps_16by9_Wide.json
@@ -1,0 +1,50 @@
+{
+    "name": "Hawkeye Firefly X Lite 2.5K 50fps 16by9 Wide",
+    "note": "",
+    "calibrated_by": "Soukron",
+    "camera_brand": "Hawkeye",
+    "camera_model": "Firefly X Lite",
+    "lens_model": "",
+    "camera_setting": "2.5K 50fps 16by9 Wide",
+    "calibrator_version": "0.3.0-beta/dev",
+    "date": "2021-08-18",
+    "calib_dimension": {
+        "w": 2560,
+        "h": 1440
+    },
+    "orig_dimension": {
+        "w": 2560,
+        "h": 1440
+    },
+    "input_horizontal_stretch": 1,
+    "num_images": 19,
+    "use_opencv_fisheye": true,
+    "fisheye_params": {
+        "RMS_error": 0.7716322941169201,
+        "camera_matrix": [
+            [
+                1659.6051209101186,
+                0.0,
+                1280.0
+            ],
+            [
+                0.0,
+                1661.6735210206514,
+                720.0
+            ],
+            [
+                0.0,
+                0.0,
+                1.0
+            ]
+        ],
+        "distortion_coeffs": [
+            -0.016317628844791328,
+            0.05790705794184552,
+            -0.15567501811495787,
+            0.13431450363568642
+        ]
+    },
+    "use_opencv_standard": false,
+    "calib_params": {}
+}

--- a/camera_presets/Hawkeye/Hawkeye_Firefly_X_Lite_2_7K_50fps_Ultra_Wide.json
+++ b/camera_presets/Hawkeye/Hawkeye_Firefly_X_Lite_2_7K_50fps_Ultra_Wide.json
@@ -1,0 +1,50 @@
+{
+    "name": "Hawkeye Firefly X Lite 2.7K 50fps Ultra Wide",
+    "note": "",
+    "calibrated_by": "Soukron",
+    "camera_brand": "Hawkeye",
+    "camera_model": "Firefly X Lite",
+    "lens_model": "",
+    "camera_setting": "2.7K 50fps Ultra Wide",
+    "calibrator_version": "0.3.0-beta/dev",
+    "date": "2021-08-18",
+    "calib_dimension": {
+        "w": 2704,
+        "h": 1520
+    },
+    "orig_dimension": {
+        "w": 2704,
+        "h": 1520
+    },
+    "input_horizontal_stretch": 1,
+    "num_images": 21,
+    "use_opencv_fisheye": true,
+    "fisheye_params": {
+        "RMS_error": 0.40565103160354293,
+        "camera_matrix": [
+            [
+                1369.432731255863,
+                0.0,
+                1352.0
+            ],
+            [
+                0.0,
+                1037.3205969634014,
+                760.0
+            ],
+            [
+                0.0,
+                0.0,
+                1.0
+            ]
+        ],
+        "distortion_coeffs": [
+            -0.03982708088924714,
+            0.02761520782279934,
+            -0.03606839793988838,
+            0.015490536807408825
+        ]
+    },
+    "use_opencv_standard": false,
+    "calib_params": {}
+}

--- a/camera_presets/Hawkeye/Hawkeye_Firefly_X_Lite_4K_50fps_16by9_Wide.json
+++ b/camera_presets/Hawkeye/Hawkeye_Firefly_X_Lite_4K_50fps_16by9_Wide.json
@@ -1,0 +1,50 @@
+{
+    "name": "Hawkeye Firefly X Lite 4K 50fps 16by9 Wide",
+    "note": "",
+    "calibrated_by": "Soukron",
+    "camera_brand": "Hawkeye",
+    "camera_model": "Firefly X Lite",
+    "lens_model": "",
+    "camera_setting": "4K 50fps 16by9 Wide",
+    "calibrator_version": "0.3.0-beta/dev",
+    "date": "2021-08-18",
+    "calib_dimension": {
+        "w": 3840,
+        "h": 2160
+    },
+    "orig_dimension": {
+        "w": 3840,
+        "h": 2160
+    },
+    "input_horizontal_stretch": 1,
+    "num_images": 13,
+    "use_opencv_fisheye": true,
+    "fisheye_params": {
+        "RMS_error": 0.663427618895264,
+        "camera_matrix": [
+            [
+                2018.8621881460358,
+                0.0,
+                1920.0
+            ],
+            [
+                0.0,
+                2020.5248431831853,
+                1080.0
+            ],
+            [
+                0.0,
+                0.0,
+                1.0
+            ]
+        ],
+        "distortion_coeffs": [
+            -0.04786702304439173,
+            0.030501271674783222,
+            -0.024774117363406668,
+            -0.024977346888174837
+        ]
+    },
+    "use_opencv_standard": false,
+    "calib_params": {}
+}


### PR DESCRIPTION
Added the three default presets in the Hawkeye Firefly X Lite camera:
- 4K (3840×2160) 50fps 16:9
- 2.7K 50fps SuperView 
- 2.5K 50fps 16:9 EIS 