### PR TITLE
feat(gopro): use cori and iori instead of gyro when available

### DIFF
--- a/gyro_integrator.py
+++ b/gyro_integrator.py
@@ -10,7 +10,7 @@ import quaternion as quat
 import smoothing_algos
 
 class GyroIntegrator:
-    def __init__(self, gyro_data, time_scaling=1, gyro_scaling=1, zero_out_time=True, initial_orientation=None, acc_data=None, acc_scaling=1):
+    def __init__(self, gyro_data, orientation_list=None, time_list=None, time_scaling=1, gyro_scaling=1, zero_out_time=True, initial_orientation=None, acc_data=None, acc_scaling=1):
         """Initialize instance of gyroIntegrator for getting orientation from gyro data
 
         Args:
@@ -79,8 +79,8 @@ class GyroIntegrator:
             self.orientation = np.array([1, 0.0001, 0.0001, 0.0001])
 
         # Variables to save integration data
-        self.orientation_list = None
-        self.time_list = None
+        self.orientation_list = orientation_list
+        self.time_list = time_list
 
         # IMU reference vectors
         self.imuRefX = quat.vector(1,0,0)
@@ -91,7 +91,7 @@ class GyroIntegrator:
         # points upwards, since it's equivalent to an upwards acceleration at rest
         self.grav_vec = np.array([0,1,0]) # Per convention it's upwards
 
-        self.already_integrated = False
+        self.already_integrated = type(orientation_list) != type(None)
 
         self.smoothing_algo = None
 

--- a/gyrolog.py
+++ b/gyrolog.py
@@ -14,6 +14,7 @@ from scipy.fft import fft, fftfreq
 import insta360_utility as insta360_util
 from blackbox_extract import BlackboxExtractor
 from GPMF_gyro import Extractor as GPMFExtractor
+from quaternion import quaternion_multiply
 
 
 # Generate 24 different (right handed) orientations using cross products
@@ -194,6 +195,7 @@ class GyrologReader:
         # The scaled data read from the file
         self.gyro = None # N*4 array with each column containing [t, gx, gy, gz]
         self.acc = None # N*4 array with each column containing [t, ax, ay, az]
+        self.orientations = None # N*4 array with each column containing [w, x, y, z], one for each frame
 
         # The transformed data according to the gyroflow convention
         self.standard_gyro = None
@@ -201,6 +203,7 @@ class GyrologReader:
 
         self.extracted = False
         self.has_acc = False
+        self.has_orientations = False
         # Assume same time reference and orientation used for both
 
         self.default_filter = -1
@@ -360,6 +363,11 @@ class GyrologReader:
     def get_acc(self):
         if self.extracted and self.has_acc:
             return self.acc
+        return None
+
+    def get_orientations(self):
+        if self.extracted and self.has_orientations:
+            return self.orientations
         return None
 
     def apply_rotation(self, rotmat, time_data):
@@ -948,7 +956,12 @@ class GPMFLog(GyrologReader):
             self.gyro = self.gpmf.get_gyro(True)
             self.gpmf.parse_accl()
             self.acc = self.gpmf.get_accl(True)
-            
+
+            if self.gpmf.has_cori:
+                # Combine CORI and IORI
+                self.orientations = np.array([quaternion_multiply(CORI, IORI) for CORI, IORI in zip(self.gpmf.get_cori(), self.gpmf.get_iori())])
+                self.has_orientations = True
+
             minlength = min(self.gyro.shape[0], self.acc.shape[0])
             maxlength = max(self.gyro.shape[0], self.acc.shape[0])
             # Make sure they match

--- a/stabilizer.py
+++ b/stabilizer.py
@@ -1,4 +1,4 @@
-#from quaternion import quaternion
+from quaternion import quaternion_multiply
 import numpy as np
 from datetime import date
 import cv2
@@ -118,6 +118,8 @@ class Stabilizer:
         self.times = None
         self.stab_transform = None
         self.smoothing_algo = None
+        self.orientations = None
+        self.has_orientations = False
 
         self.initial_orientation = Rotation.from_euler('zxy', [0,0,np.pi/2]).as_quat()
         self.initial_orientation[[0,1,2,3]] = self.initial_orientation[[3,0,1,2]]
@@ -1864,6 +1866,9 @@ class GPMFStabilizer(Stabilizer):
         self.gpmf = Extractor(gyro_path)
         self.gyro_data = self.gpmf.get_gyro(True)
 
+        # Combine CORI and IORI
+        self.orientations = np.array([quaternion_multiply(CORI, IORI) for CORI, IORI in zip(self.gpmf.get_cori(), self.gpmf.get_iori())])
+
         # Hero 6??
         if hero == 6:
             self.gyro_data[:,1] = self.gyro_data[:,1]
@@ -1898,6 +1903,7 @@ class GPMFStabilizer(Stabilizer):
 
         self.integrator = GyroIntegrator(self.gyro_data,initial_orientation=initial_orientation)
         self.integrator.integrate_all(use_acc=False)
+
         self.times = None
         self.stab_transform = None
 
@@ -2046,9 +2052,17 @@ class MultiStabilizer(Stabilizer):
         initial_orientation = Rotation.from_euler('zxy', [0,0,np.pi/2]).as_quat()
         initial_orientation[[0,1,2,3]] = initial_orientation[[3,0,1,2]]
 
+        # self.orientations is one quaternion per frame, if available (gopro hero 8 and newer)
+        self.orientations = self.log_reader.get_orientations()
+        time_list = np.arange(self.orientations.shape[0]) * (1/self.fps) if type(self.orientations) != type(None) else None
 
-        self.integrator = GyroIntegrator(self.gyro_data,initial_orientation=initial_orientation, acc_data=self.acc_data)
-        self.integrator.integrate_all(use_acc=False)
+        self.integrator = GyroIntegrator(self.gyro_data, initial_orientation=initial_orientation, acc_data=self.acc_data, orientation_list=self.orientations, time_list=time_list)
+
+        if type(self.orientations) != type(None):
+            self.new_integrator = self.integrator
+        else:
+            self.integrator.integrate_all(use_acc=False)
+
         self.times = None
         self.stab_transform = None
 


### PR DESCRIPTION
On GoPro Hero 8, 9 and 10 there are CORI and IORI gpmf data which is
exact camera orientation and image orientation respectively per frame.
Uses that intead of gyro data if it is available.

This IORI is the image orientation relative to camera body, which means
we can now stabilize videos recorded with hypersmooth.

TODO: Make this work in the GUI. Only works via CLI right now.

fixes #51