### PR TITLE
Runcam 5 orange audio problem fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ scipy = "^1.6.0"
 pandas = "^1.3.2"
 qdarkstyle = "^3.0.0"
 darkdetect = "^0.5.0"
+ffprobe-python = "^1.0.3"
 
 [tool.poetry.dev-dependencies]
 

--- a/stabilizer.py
+++ b/stabilizer.py
@@ -29,6 +29,7 @@ from matplotlib import pyplot as plt
 from matplotlib import colors
 from vidgear.gears import WriteGear
 from vidgear.gears import helper as vidgearHelper
+from ffprobe import FFProbe
 import gyrolog
 import json
 import multiprocessing as mp
@@ -1252,6 +1253,17 @@ class Stabilizer:
         if type(viewer_thread) != type(None):
             viewer_thread.map_function_enable = old_map_enable_setting
 
+        audio_codec = "copy"
+
+        try:
+            metadata = FFProbe(self.videopath)
+            audio_streams = filter(lambda x: x.is_audio(), metadata.streams)
+            audio_stream = next(audio_streams)
+            if audio_stream.codec() == "pcm_s16le": #This audio codec can't be put inside an MP4 file, so transcode is needed
+                audio_codec = "aac"
+        except IOError as error:
+            if "ffprobe not found" in str(error):
+                print("FFProbe not found, the audio stream will be not transcoded")
 
         if audio:
             time.sleep(.5)
@@ -1265,7 +1277,7 @@ class Stabilizer:
                 str(tend / self.fps),
                 "-vn",
                 "-acodec",
-                "copy",
+                audio_codec,
                 "audio.mp4"
             ]
             out.execute_ffmpeg_cmd(ffmpeg_command)

--- a/stabilizer.py
+++ b/stabilizer.py
@@ -1253,19 +1253,18 @@ class Stabilizer:
         if type(viewer_thread) != type(None):
             viewer_thread.map_function_enable = old_map_enable_setting
 
-        audio_codec = "copy"
-
-        try:
-            metadata = FFProbe(self.videopath)
-            audio_streams = filter(lambda x: x.is_audio(), metadata.streams)
-            audio_stream = next(audio_streams)
-            if audio_stream.codec() == "pcm_s16le": #This audio codec can't be put inside an MP4 file, so transcode is needed
-                audio_codec = "aac"
-        except IOError as error:
-            if "ffprobe not found" in str(error):
-                print("FFProbe not found, the audio stream will be not transcoded")
-
         if audio:
+            audio_codec = "copy"
+            try:
+                metadata = FFProbe(self.videopath)
+                audio_streams = filter(lambda x: x.is_audio(), metadata.streams)
+                audio_stream = next(audio_streams)
+                if audio_stream.codec() == "pcm_s16le":  # This audio codec can't be put inside an MP4 file, so transcode is needed
+                    audio_codec = "aac"
+            except IOError as error:
+                if "ffprobe not found" in str(error):
+                    print("FFProbe not found, the audio stream will be not transcoded")
+
             time.sleep(.5)
             ffmpeg_command = [
                 "-y",


### PR DESCRIPTION
Fixs issue #91  
RunCam 5 orange uses **pcm_s16le** as audio codec, ffmpeg doesn't allow to use this codec inside mp4 files, so now the audio render fails.
With this PR if the audio codec of the original source is **pcm_s16le**, it will do a transcodition to AAC, otherwise it will use the same codec of the original clip.

We can also do the audio transcodition for all clips (to avoid ffprobe dependecy) but i preferet to do the transcodition only when needed.