### PR TITLE
fix for GoPro HERO9

### DIFF
--- a/gpmf/extract.py
+++ b/gpmf/extract.py
@@ -105,8 +105,7 @@ def find_gpmd_minf_atom(parser):
                         #print("    {}".format(tag))
                         if tag.value != 'gmhd':
                             continue
-                        if b'gpmd' in minf_field['data'].value:
-                            return minf_atom
+                        return minf_atom
         except MissingField:
             pass
         try:


### PR DESCRIPTION
Thank you for providing such a great software.

I would like to use the MP4 file output by the GoPro HERO9 as a source of gyro data, but it did not work.

The MP4 files output by the newer GoPros seem to have a different atom hierarchy. gpmd is no longer a child element of gmhd.

```
             Atom minf @ 329465 of size: 3292, ends @ 332757
                 Atom gmhd @ 329473 of size: 32, ends @ 329505
                 Atom dinf @ 329505 of size: 36, ends @ 329541
                     Atom dref @ 329513 of size: 28, ends @ 329541
                         Atom alis @ 329529 of size: 12, ends @ 329541
                 Atom stbl @ 329541 of size: 3216, ends @ 332757
                     Atom stsd @ 329549 of size: 32, ends @ 329581
                         Atom gpmd @ 329565 of size: 16, ends @ 329581            
```

I changed the gmhd to just make sure it exists directly under the minf.

I was able to get gyroflow working on my GoPro HERO9.


All outputs.
```
$ AtomicParsley test.mp4 -T 1
﻿Atom ftyp @ 0 of size: 32, ends @ 32
Atom moov @ 32 of size: 359182, ends @ 359214
     Atom mvhd @ 40 of size: 108, ends @ 148
     Atom trak @ 148 of size: 183883, ends @ 184031
         Atom tkhd @ 156 of size: 92, ends @ 248
         Atom mdia @ 248 of size: 183727, ends @ 183975
             Atom mdhd @ 256 of size: 32, ends @ 288
             Atom hdlr @ 288 of size: 44, ends @ 332
             Atom minf @ 332 of size: 183643, ends @ 183975
                 Atom vmhd @ 340 of size: 20, ends @ 360
                 Atom hdlr @ 360 of size: 33, ends @ 393
                 Atom dinf @ 393 of size: 36, ends @ 429
                     Atom dref @ 401 of size: 28, ends @ 429
                         Atom alis @ 417 of size: 12, ends @ 429
                 Atom stbl @ 429 of size: 183546, ends @ 183975
                     Atom stsd @ 437 of size: 198, ends @ 635
                         Atom avc1 @ 453 of size: 182, ends @ 635
                             Atom colr @ 539 of size: 19, ends @ 558                     ~
                             Atom avcC @ 558 of size: 57, ends @ 615
                             Atom btrt @ 615 of size: 20, ends @ 635
                     Atom stsz @ 635 of size: 46128, ends @ 46763
                     Atom stsc @ 46763 of size: 28, ends @ 46791
                     Atom stco @ 46791 of size: 46124, ends @ 92915
                     Atom stts @ 92915 of size: 24, ends @ 92939
                     Atom stss @ 92939 of size: 788, ends @ 93727
                     Atom ctts @ 93727 of size: 90248, ends @ 183975
         Atom edts @ 183975 of size: 36, ends @ 184011
             Atom elst @ 183983 of size: 28, ends @ 184011
         Atom tref @ 184011 of size: 20, ends @ 184031
             Atom tmcd @ 184019 of size: 12, ends @ 184031                               ~
     Atom trak @ 184031 of size: 144724, ends @ 328755
         Atom tkhd @ 184039 of size: 92, ends @ 184131
         Atom mdia @ 184131 of size: 144588, ends @ 328719
             Atom mdhd @ 184139 of size: 32, ends @ 184171
             Atom hdlr @ 184171 of size: 33, ends @ 184204
             Atom minf @ 184204 of size: 144515, ends @ 328719
                 Atom smhd @ 184212 of size: 16, ends @ 184228
                 Atom hdlr @ 184228 of size: 33, ends @ 184261
                 Atom dinf @ 184261 of size: 36, ends @ 184297
                     Atom dref @ 184269 of size: 28, ends @ 184297
                         Atom alis @ 184285 of size: 12, ends @ 184297
                 Atom stbl @ 184297 of size: 144422, ends @ 328719
                     Atom stsd @ 184305 of size: 102, ends @ 184407
                         Atom mp4a @ 184321 of size: 86, ends @ 184407
                             Atom esds @ 184357 of size: 50, ends @ 184407
                     Atom stsz @ 184407 of size: 72132, ends @ 256539
                     Atom stsc @ 256539 of size: 28, ends @ 256567
                     Atom stco @ 256567 of size: 72128, ends @ 328695
                     Atom stts @ 328695 of size: 24, ends @ 328719
         Atom edts @ 328719 of size: 36, ends @ 328755
             Atom elst @ 328727 of size: 28, ends @ 328755
     Atom trak @ 328755 of size: 528, ends @ 329283
         Atom tkhd @ 328763 of size: 92, ends @ 328855
         Atom mdia @ 328855 of size: 392, ends @ 329247
             Atom mdhd @ 328863 of size: 32, ends @ 328895
             Atom hdlr @ 328895 of size: 33, ends @ 328928
             Atom minf @ 328928 of size: 319, ends @ 329247
                 Atom gmhd @ 328936 of size: 80, ends @ 329016
                 Atom hdlr @ 329016 of size: 33, ends @ 329049
                 Atom dinf @ 329049 of size: 36, ends @ 329085
                     Atom dref @ 329057 of size: 28, ends @ 329085
                         Atom alis @ 329073 of size: 12, ends @ 329085
                 Atom stbl @ 329085 of size: 162, ends @ 329247
                     Atom stsd @ 329093 of size: 62, ends @ 329155
                         Atom tmcd @ 329109 of size: 46, ends @ 329155
                     Atom stsz @ 329155 of size: 20, ends @ 329175
                     Atom stsc @ 329175 of size: 28, ends @ 329203
                     Atom stco @ 329203 of size: 20, ends @ 329223
                     Atom stts @ 329223 of size: 24, ends @ 329247
         Atom edts @ 329247 of size: 36, ends @ 329283
             Atom elst @ 329255 of size: 28, ends @ 329283
     Atom trak @ 329283 of size: 3510, ends @ 332793
         Atom tkhd @ 329291 of size: 92, ends @ 329383
         Atom mdia @ 329383 of size: 3374, ends @ 332757
             Atom mdhd @ 329391 of size: 32, ends @ 329423
             Atom hdlr @ 329423 of size: 42, ends @ 329465
             Atom minf @ 329465 of size: 3292, ends @ 332757
                 Atom gmhd @ 329473 of size: 32, ends @ 329505
                 Atom dinf @ 329505 of size: 36, ends @ 329541
                     Atom dref @ 329513 of size: 28, ends @ 329541
                         Atom alis @ 329529 of size: 12, ends @ 329541
                 Atom stbl @ 329541 of size: 3216, ends @ 332757
                     Atom stsd @ 329549 of size: 32, ends @ 329581
                         Atom gpmd @ 329565 of size: 16, ends @ 329581                   ~
                     Atom stsz @ 329581 of size: 1560, ends @ 331141
                     Atom stsc @ 331141 of size: 28, ends @ 331169
                     Atom stco @ 331169 of size: 1556, ends @ 332725
                     Atom stts @ 332725 of size: 32, ends @ 332757
         Atom edts @ 332757 of size: 36, ends @ 332793
             Atom elst @ 332765 of size: 28, ends @ 332793
     Atom udta @ 332793 of size: 26421, ends @ 359214
         Atom FIRM @ 332801 of size: 23, ends @ 332824                                   ~
         Atom GPMF @ 332824 of size: 25608, ends @ 358432                                        ~
         Atom CAME @ 358432 of size: 24, ends @ 358456                                   ~
         Atom SETT @ 358456 of size: 20, ends @ 358476                                   ~
         Atom LENS @ 358476 of size: 56, ends @ 358532                                   ~
         Atom HMMT @ 358532 of size: 412, ends @ 358944                                  ~
         Atom MUID @ 358944 of size: 40, ends @ 358984                                   ~
         Atom BCID @ 358984 of size: 44, ends @ 359028                                   ~
         Atom GUMI @ 359028 of size: 24, ends @ 359052                                   ~
         Atom free @ 359052 of size: 132, ends @ 359184
         Atom ©xyz @ 359184 of size: 30, ends @ 359214                                   ~
Atom free @ 359214 of size: 137720, ends @ 496934
Atom mdat @ 496934 of size: 612600050, ends @ 613096984

 ~ denotes an unknown atom
------------------------------------------------------
Total size: 613096984 bytes; 103 atoms total.
Media data: 612600050 bytes; 496934 bytes all other atoms (0.081% atom overhead).
Total free atom space: 137852 bytes; 0.022% waste. Padding available: 137852 bytes.
------------------------------------------------------
AtomicParsley version: 0.9.6 (utf8)
------------------------------------------------------
Movie duration: 384.618 seconds (06:24.62) - 12742.01* kbp/sec bitrate (*=approximate)
Low-level details. Total tracks: 4
Trk  Type  Handler                    Kind  Lang  Bytes
1    vide  GoPro H.265                avc1  ```   600850181
     12497.61* kbp/s  384.618 sec  AVC High Profile,  Level 4  1920x1080  (8040 macroblocks)
2    soun  [none listed]              mp4a  ```   9102713
     48.00 kbp/s  MPEG-4 AAC Low Complexity/LC Profile    channels: [2]
3    tmcd  [none listed]              tmcd  ```   4
4    meta  GoPro MET                  gpmd  ```   2647144
```